### PR TITLE
EIQ-5032: get rid of snap-refresh-control

### DIFF
--- a/snap/local/snapcraft.template.yaml
+++ b/snap/local/snapcraft.template.yaml
@@ -39,7 +39,6 @@ apps:
       - home
       - shutdown
       - snapd-control
-      - snap-refresh-control
       - hardware-observe
       - network
       - network-bind


### PR DESCRIPTION
Drop unnecessary plug, based in the discussion here: https://forum.snapcraft.io/t/request-for-access-to-snapd-control-interface-for-edgeiq-coda-snap/40670